### PR TITLE
chore: update Apache-2.0 license copyright placeholder

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -58,7 +58,7 @@ APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 OpenControlPlane contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What

Replace the Apache-2.0 license copyright placeholder with the correct project copyright.

- `LICENSE`: `Copyright [yyyy] [name of copyright owner]` → `Copyright 2026 OpenControlPlane contributors`
- `LICENSES/Apache-2.0.txt`: same replacement

## Why

Per [NeoNephos Project Guidelines](https://github.com/neonephos/guidelines-development/blob/main/project-guidelines/project-guidelines.md). Part of https://github.com/openmcp-project/backlog/issues/533.